### PR TITLE
Feat: mission3

### DIFF
--- a/react/hello-react/src/App.js
+++ b/react/hello-react/src/App.js
@@ -1,23 +1,12 @@
-import logo from './logo.svg';
-import './App.css';
+import ScrollBox from './ScrollBox';
+import { useRef } from 'react';
 
-function App() {
+const App = () => {
+  const scrollBoxRef = useRef();
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div>
+      <ScrollBox ref={scrollBoxRef}></ScrollBox>
+      <button onClick={() => scrollBoxRef.current.scrolltoEnd()}>맨 밑으로</button>
     </div>
   );
 }

--- a/react/hello-react/src/ScrollBox.css
+++ b/react/hello-react/src/ScrollBox.css
@@ -1,0 +1,11 @@
+.container {
+    width: 300px;
+    height: 300px;
+    overflow: auto;
+}
+
+.content {
+    width: 100%;
+    height: 600px;
+    background: linear-gradient(magenta, cyan, yellow);
+}

--- a/react/hello-react/src/ScrollBox.js
+++ b/react/hello-react/src/ScrollBox.js
@@ -1,0 +1,19 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import './ScrollBox.css';
+
+let ScrollBox = (props, ref) => {
+    const contentRef = useRef();
+    useImperativeHandle(ref, () => ({
+        scrolltoEnd() {
+            contentRef.current.scrollIntoView(false);
+        }
+    }));
+    return (
+        <div class="container">
+            <div class="content" ref={contentRef}></div>
+        </div>
+    );
+}
+ScrollBox = forwardRef(ScrollBox);
+
+export default ScrollBox;


### PR DESCRIPTION
1. `createRef`와 `useRef`의 차이 : `createRef`는 [리렌더링될 때마다 ref 값이 null로 초기화](https://github.com/facebook/react/blob/8ccfce460f141299d61290f877745407e05e531e/packages/react/src/ReactCreateRef.js#L14)되므로 `useRef`의 사용이 추천됨
2. 함수 컴포넌트는 인스턴스가 없기 때문에 `forwardRef`, `useImperativeHandle` 를 사용
    - `forwardRef` : 부모에서 jsx 속성으로 전달-> forwardRef의 두번째 ref 파라미터로 전달
    - `useImperativeHandle` : 자식 입장에서 이 ref가 부모에게서 왔다는 보장이 없으므로 (ex: 부모가 ref를 넘기지 않아 null로 넘어왔다거나) 이를 방지하기 위한 [proxy reference](https://kelly-kh-woo.medium.com/react-hook-useimperativehandle-89fee716d80)의 역할을 함. 컴포넌트 간의 독립성 보장
3. [element.scrollIntoView(bool)](https://developer.mozilla.org/ko/docs/Web/API/Element/scrollIntoView) 
    - bool값이 true면 element의 top으로 scroll 
    - bool값이 false면 bottom으로 scroll 
    
**[Before]**
![before](https://user-images.githubusercontent.com/46990061/125450952-cc48d04e-6cfb-44d3-9b95-ac1e1482a8a4.JPG)

**[After]**
![after](https://user-images.githubusercontent.com/46990061/125450973-cb7fa19b-8d28-49de-903e-81ac449eb2d0.JPG)